### PR TITLE
Add name when printing a PSPresentation

### DIFF
--- a/packages/BaselineOfPresenter.package/BaselineOfPresenter.class/instance/projectClass.st
+++ b/packages/BaselineOfPresenter.package/BaselineOfPresenter.class/instance/projectClass.st
@@ -1,0 +1,6 @@
+baseline
+projectClass
+	"Changing the projectClass allows for updates to Autocompletion without adding metadata to the FileTree repository."
+   ^ Smalltalk 
+	at: #MetacelloCypressBaselineProject
+	ifAbsent: [super projectClass]

--- a/packages/BaselineOfPresenter.package/BaselineOfPresenter.class/methodProperties.json
+++ b/packages/BaselineOfPresenter.package/BaselineOfPresenter.class/methodProperties.json
@@ -4,4 +4,5 @@
 	"instance" : {
 		"baseline:" : "VO 6/4/2019 17:07",
 		"postLoad" : "LM 6/13/2018 13:51",
-		"preLoad" : "LM 6/20/2018 18:45" } }
+		"preLoad" : "LM 6/20/2018 18:45",
+		"projectClass" : "LM 11/6/2023 18:25" } }

--- a/packages/Presenter-Core.package/PSPresentation.class/instance/printOn..st
+++ b/packages/Presenter-Core.package/PSPresentation.class/instance/printOn..st
@@ -1,0 +1,6 @@
+as yet unclassified
+printOn: aStream
+
+	super printOn: aStream.
+	aStream nextPutAll: ': '.
+	aStream print: self name.

--- a/packages/Presenter-Core.package/PSPresentation.class/methodProperties.json
+++ b/packages/Presenter-Core.package/PSPresentation.class/methodProperties.json
@@ -23,6 +23,7 @@
 		"moveSlideAt:to:" : "LM 7/13/2018 18:27",
 		"name" : "LM 8/1/2023 10:59",
 		"name:" : "LM 7/31/2023 17:02",
+		"printOn:" : "LM 11/6/2023 18:32",
 		"slideAt:" : "LM 7/13/2018 18:11",
 		"slideCount" : "LM 7/13/2018 17:34",
 		"slideLayouts" : "mb 4/25/2019 16:57",


### PR DESCRIPTION
additionally change the projectClass of the Baseline.
That way future updates should be doable using Metacello.

See the same projectClass code in https://github.com/LeonMatthes/Autocompletion